### PR TITLE
Fix parsing items with spaces in their names

### DIFF
--- a/app/models/items.server.ts
+++ b/app/models/items.server.ts
@@ -66,7 +66,7 @@ function calculateTotalValueOfItems(orderData: finalMarketOrderData, items: stri
   // Loop through the keys of passed in items and find the highest prices
   for (const order of Object.keys(orderData)) {
     items.forEach((item) => {
-      const itemName = item.slice(0, -1).join(' ');
+      const itemName = item[0];
 
       if (itemName === order) {
         console.log(`We found a matching order for: ${itemName}`)

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -6,7 +6,9 @@
 export function splitItemIntoNameAndQty(items: string ): string[][] {
   let splitItems = items?.split('\n').map((line) => {
     line.replace('\r', '')
-    return line.split(/[\s|\t]/);
+    let splitLine = line.split(/[\s|\t]/);
+    return [splitLine.slice(0,-1).join(" "), 
+    	splitLine[splitLine.length - 1]];
   });
 
   // Setup variable to house delete positions
@@ -60,7 +62,7 @@ export function parsePropsAndCreateItemNameList(splitItemsArray: string[][]): st
   if (splitItemsArray.length > 1) {
     splitItemsArray.forEach((item) => {
       if (doesItemHaveQty(item)) {
-        itemNameList.push(item.slice(0, -1).join(' '))
+        itemNameList.push(item[0])
       }
     });
   } else if (splitItemsArray.length === 1 && splitItemsArray[0] !== undefined) {


### PR DESCRIPTION
Querying with values such as

```
Concentrated Veldspar 1
```

lead into the code parsing the item as `["Concentrated", "Veldspar", "1"]` instead of the correct `["Concentrated Veldspar", "1"]`. This lead into the program returning an invalid value.

This patch fixes that behavior.